### PR TITLE
Switch to 42.5.0 to align with other projects.

### DIFF
--- a/eapxp4/app.yaml
+++ b/eapxp4/app.yaml
@@ -7,7 +7,7 @@ build:
       - name: MAVEN_ARGS_APPEND
         value: "-DskipTests -DfailOnMissingWebXml=false -Dquarkus.container-image.push=false"
       - name: POSTGRESQL_DRIVER_VERSION
-        value: '42.2.19'
+        value: '42.5.0'
   s2i:
     featurePacks:
       - org.jboss.eap:eap-datasources-galleon-pack:7.4.0.GA-redhat-00003


### PR DESCRIPTION
Considering 42.2.19 is not available in the maven repo switching to 42.5.0 makes sense. 