### PR TITLE
Remove unsupported configuration.

### DIFF
--- a/eapxp4/app.yaml
+++ b/eapxp4/app.yaml
@@ -34,21 +34,8 @@ deploy:
       value: "5432"
     - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
       value: frdemo-kafka:9092
-  maxReplicas: 10
-  metrics:
-  - resource:
-      name: cpu
-      target:
-        averageUtilization: 100
-        type: Utilization
-    type: Resource
-  minReplicas: 1
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: frdemo
-  containers:
-    - resources:
-        requests:
-          cpu: 100m
-          memory: 500Mi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+  replicas: 1


### PR DESCRIPTION
Following a conversation about [EAP helm chart configuration](https://github.com/jbossas/eap-charts/issues/46) this PR  updates the configuration. To only keep supported yaml.